### PR TITLE
Revise treatment of keywords in non-key position

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,13 @@ You should now be able to go to the example's directory and open the
    primitives stay the same. The most notable difference is that `cljs->js`
    turns keywords into strings, but we're making no such cast on the JVM.
 
-   Strings and boolean are stable.
+   Strings and boolean are stable, and stored using the corresponding
+   primitives. Keywords are also stable, but are stored as colon-prefixed
+   strings, which are "auto-magically" rehydrated.
 
    Numbers are stable in JS. On the JVM Numbers are stable for the core cases of
    Long and Double, although  more exotic types like `java.math.BigDec` will be
    cast down.
-
-   Keywords are reduced to names in JS. On the JVM things get more "interesting":
-   they're picked up as associative data, and become maps. The look something
-   like (`{:sym {"name" "b", "namespace" "a"}, :name "b", :namespace "a"}` if
-   you must know. Perhaps a better behaviour would be to store them as colon
-   prefixed strings, and have some magic to automatically hydrate such strings
-   as keywords.
 
    Records are saved as regular maps. Types defined with `deftype` also cast
    down to maps, but their attributes for some reason are `under_scored` rather

--- a/src/matchbox/core.cljx
+++ b/src/matchbox/core.cljx
@@ -14,7 +14,7 @@
   (:require [clojure.string :as str]
             [matchbox.utils :as utils]
             [matchbox.registry :refer [register-listener]]
-            #+clj [clojure.walk :as walk]
+            [clojure.walk :as walk]
             #+cljs cljsjs.firebase))
 
 ;; TODO: JVM register + unsubscribe listeners
@@ -187,7 +187,7 @@
   #+clj (if-not cb
           (.setValue ref (serialize val) priority)
           (.setValue ref (serialize val) priority (wrap-cb cb)))
-  #+cljs (.setWithPriority ref (serialize val) priority cb))
+  #+cljs (.setWithPriority ref (serialize val) priority (or cb undefined)))
 
 (defn merge! [ref val & [cb]]
   #+clj
@@ -303,7 +303,6 @@
 (defn reset-in! [ref korks val & [cb]]
   (reset! (get-in ref korks) val cb))
 
-#+cljs
 (defn reset-with-priority-in! [ref korks val priority & [cb]]
   (reset-with-priority! (get-in ref korks) val priority cb))
 

--- a/test/matchbox/core_test.clj
+++ b/test/matchbox/core_test.clj
@@ -26,9 +26,11 @@
     (is (contains? tran "hello"))
     (is (not (contains? tran :hello))))
   ;; values are unchanged
-  (testing "bool, long, float, vector, string, keyword, set, list"
-    (doseq [x [true [1 2 3 4] 150.0 "hello" :a #{1 2 3} '(3 2 1)]]
-      (is (= x (m/serialize x))))))
+  (testing "bool, long, float, vector, string, set, list"
+    (doseq [x [true [1 2 3 4] 150.0 "hello" #{1 2 3} '(3 2 1)]]
+      (is (= x (m/serialize x)))))
+  (testing "keyword"
+    (is (= ":a" (m/serialize :a)))))
 
 (deftest hydrate-test
   ;; map keys from strings -> keywords
@@ -62,8 +64,8 @@
     (is (= "feeling myself" (round-trip "feeling myself"))))
 
   (testing "keyword"
-    ;; FIXME: inconsistent with CLJS
-    (is (= {:sym {:name "a"}, :name "a"} (round-trip :a))))
+    (is (= :a (round-trip :a)))
+    (is (= :ns/key (round-trip :ns/key))))
 
   (testing "map"
     (is (= {:a 1, :b 2}

--- a/test/matchbox/core_test.cljs
+++ b/test/matchbox/core_test.cljs
@@ -123,10 +123,10 @@
 (deftest ^:async auth-anon-test
   (let [ref (random-ref)]
     (is (nil? (p/auth-info ref)))
-    ;; not a happy test right now, haven't figured why tests don't connect
     (p/auth-anon ref (fn [error auth-data]
-                       (is (nil? auth-data))
-                       (is (and error
-                                (= (.-message error)
-                                   "Unable to contact the Firebase server.")))
+                       (is (= "anonymous" (:provider auth-data)))
+                       (is (not error))
+                       (is (= (p/auth-info ref) auth-data))
+                       (p/unauth ref)
+                       (is (nil? (p/auth-info ref)))
                        (done)))))

--- a/test/matchbox/core_test.cljs
+++ b/test/matchbox/core_test.cljs
@@ -105,7 +105,7 @@
     (p/reset-with-priority-in! ref "b" 2 0)
     (p/reset-in! ref "c" 3)
     (p/deref ref (fn [v] (is (= [3 2 1] (vals v))) (done)))
-    (js/setTimeout (fn [] (is (not "timeout")) (done)) 1000)))
+    (js/setTimeout (fn [] (is (not "timeout")) (done)) 1500)))
 
 (deftest disconnect!-reconnect!-test
   ;; default is connected

--- a/test/matchbox/core_test.cljs
+++ b/test/matchbox/core_test.cljs
@@ -15,7 +15,7 @@
     ref))
 
 (deftest serialize-hydrate-test
-  (is (= {:a 1, :b ["b" "a"]}
+  (is (= {:a 1, :b [:b :a]}
          (p/hydrate
           (p/serialize {"a" 1, "b" #{:a :b}})))))
 


### PR DESCRIPTION
The existing behaviour seemed very problematic for two reasons:

1. Storage different between JVM and JS platforms (maps vs. names)
2. Round-trips OK for keys but not for values (on either platform)

Since non-keyword strings are highly unlikely to be colon-prefixed, decided to sprinkle some magic when fixing consistency, so that keywords can make a stable round trip.