### PR TITLE
Confirmed Node support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
    [org.clojure/core.async "0.2.374" :scope "provided"]
    [com.firebase/firebase-client-jvm "2.5.2" :exclusions [org.apache.httpcomponents/httpclient]]
    [org.apache.httpcomponents/httpclient "4.5.2"]
-   [cljsjs/firebase "2.4.1-0"]
+   ;;[cljsjs/firebase "2.4.1-0"]
+   [cljsjs/firebase-node "2.4.2-0"]
    [org.clojure/tools.namespace "0.2.11" :scope "test"]]
 
   :aot [matchbox.clojure.android-stub]
@@ -42,4 +43,10 @@
                         :source-paths ["src" "test"]
                         :compiler {:output-to "target/cljs/test.js"
                                    :main matchbox.runner
+                                   :optimizations :none}}
+                       {:id "node-test"
+                        :source-paths ["src" "test"]
+                        :compiler {:output-to "target/cljs/node-test.js"
+                                   :main matchbox.runner
+                                   :target :nodejs
                                    :optimizations :none}}]})


### PR DESCRIPTION
We are not quite there yet, looks like the `cljsjs` package needs to get some dependencies rolled in or added as deps:

```
module.js:339
    throw err;
    ^

Error: Cannot find module 'faye-websocket'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at /Users/christruter/oss/matchbox/out/firebase-node.inc.js:165:298
    at Object.<anonymous> (/Users/christruter/oss/matchbox/out/firebase-node.inc.js:277:3)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
Subprocess failed
```

Also need to find a way to swap out the dependency just for this test, and add the test to CI.
