### PR TITLE
Support configurable serialization

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -9,11 +9,12 @@
    ;; optional namespace dependencies
    [org.clojure/core.async "0.2.374" :scope "provided"]
    [reagent "0.6.0-alpha" :scope "provided"]
+   [frankiesardo/linked "1.2.6" :scope "provided"]
    ;; build tooling
    [adzerk/boot-cljs "1.7.228-1" :scope "test"]
    [adzerk/bootlaces "0.1.13" :scope "test"]
-   [adzerk/boot-test "1.1.1"]
-   [crisptrutski/boot-cljs-test "0.2.2-SNAPSHOT"]]
+   [adzerk/boot-test "1.1.1" :scope "test"]
+   [crisptrutski/boot-cljs-test "0.2.2-SNAPSHOT" :scope "test"]]
  :source-paths #{"src"})
 
 (require

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
    [org.clojure/clojurescript "1.8.34" :scope "provided"]
    [org.clojure/core.async "0.2.374" :scope "provided"]
    [reagent "0.6.0-alpha" :scope "provided"]
+   [frankiesardo/linked "1.2.6" :scope "provided"]
    [com.firebase/firebase-client-jvm "2.5.2" :exclusions [org.apache.httpcomponents/httpclient]]
    [org.apache.httpcomponents/httpclient "4.5.2"]
    [cljsjs/firebase "2.4.1-0"]

--- a/src/matchbox/core.cljc
+++ b/src/matchbox/core.cljc
@@ -29,18 +29,6 @@
     [matchbox.registry :refer [register-listener register-auth-listener disable-auth-listener!]]
     #?(:cljs cljsjs.firebase)))
 
-(defn zipsmap
-  "Like zipmap, but returning a sorted map."
-  [keys vals]
-  (loop [map (sorted-map)
-         ks (seq keys)
-         vs (seq vals)]
-    (if (and ks vs)
-      (recur (assoc map (first ks) (first vs))
-             (next ks)
-             (next vs))
-      map)))
-
 ;; constants
 
 ;; Distinct from nil/null in CLJS, useful for opting out of callbacks
@@ -136,9 +124,9 @@
 (defn- hydrate* [x]
   (cond
     #?@(:clj
-        [(instance? HashMap x) (recur (into (sorted-map) x))
+        [(instance? HashMap x) (recur (into {} x))
          (instance? ArrayList x) (recur (into [] x))])
-    (map? x) (zipsmap (map keyword (keys x)) (vals x))
+    (map? x) (zipmap (map keyword (keys x)) (vals x))
     :else (hydrate-keywords x)))
 
 (defn hydrate [v]

--- a/src/matchbox/core.cljc
+++ b/src/matchbox/core.cljc
@@ -116,11 +116,11 @@
     (defn- strip-prefix [type]
       (-> type name (str/replace #"^.+\-" "") keyword)))
 
-(def data-config (atom {:hydrate keyword/hydrate :serialize keyword/serialize}))
+(def data-config (utils/->Serializer keyword/hydrate keyword/serialize))
 
-(defn hydrate [v] ((:hydrate @data-config) v))
+(defn hydrate [x] ((utils/get-hydrate data-config) x))
 
-(defn serialize [v] ((:serialize @data-config) v))
+(defn serialize [x] ((utils/get-serialize data-config) x))
 
 (defn key
   "Last segment in reference or snapshot path"

--- a/src/matchbox/core.cljc
+++ b/src/matchbox/core.cljc
@@ -118,9 +118,9 @@
 
 (def data-config (utils/->Serializer keyword/hydrate keyword/serialize))
 
-(defn hydrate [x] ((utils/get-hydrate data-config) x))
+(defn hydrate [x] (utils/hydrate data-config x))
 
-(defn serialize [x] ((utils/get-serialize data-config) x))
+(defn serialize [x] (utils/serialize data-config x))
 
 (defn key
   "Last segment in reference or snapshot path"

--- a/src/matchbox/serialization/keyword.cljc
+++ b/src/matchbox/serialization/keyword.cljc
@@ -1,6 +1,7 @@
 (ns matchbox.serialization.keyword
   (:require
     [matchbox.serialization.plain :as plain]
+    [matchbox.utils :as utils]
     [clojure.walk :as walk]))
 
 (defn hydrate-kw [x]
@@ -19,3 +20,6 @@
   (->> (walk/stringify-keys v)
        (walk/postwalk kw->str)
        #?(:cljs clj->js)))
+
+(defn set-default! []
+  (utils/set-date-config! hydrate serialize))

--- a/src/matchbox/serialization/keyword.cljc
+++ b/src/matchbox/serialization/keyword.cljc
@@ -1,0 +1,21 @@
+(ns matchbox.serialization.keyword
+  (:require
+    [matchbox.serialization.plain :as plain]
+    [clojure.walk :as walk]))
+
+(defn hydrate-kw [x]
+  (if (and (string? x) (= \: (first x))) (keyword (subs x 1)) x))
+
+(defn hydrate-map [x]
+  (if (map? x) (into (empty x) (map (fn [[k v]] [(keyword k) v]) x)) x))
+
+(defn hydrate [v]
+  #?(:clj (walk/prewalk (comp hydrate-kw hydrate-map plain/hydrate-raw) v)
+     :cljs (walk/postwalk (comp hydrate-kw hydrate-map) (js->clj v :keywordize-keys true))))
+
+(defn kw->str [x] (if (keyword? x) (str x) x))
+
+(defn serialize [v]
+  (->> (walk/stringify-keys v)
+       (walk/postwalk kw->str)
+       #?(:cljs clj->js)))

--- a/src/matchbox/serialization/plain.cljc
+++ b/src/matchbox/serialization/plain.cljc
@@ -2,8 +2,7 @@
   (:require
     [clojure.walk :as walk]
     [matchbox.utils :as utils])
-  (:import
-    (java.util HashMap ArrayList)))
+  #?(:clj (:import (java.util HashMap ArrayList))))
 
 (defn hydrate-raw [x]
   #?(:cljs x

--- a/src/matchbox/serialization/plain.cljc
+++ b/src/matchbox/serialization/plain.cljc
@@ -1,6 +1,7 @@
 (ns matchbox.serialization.plain
   (:require
-    [clojure.walk :as walk])
+    [clojure.walk :as walk]
+    [matchbox.utils :as utils])
   (:import
     (java.util HashMap ArrayList)))
 
@@ -19,3 +20,6 @@
 (defn serialize [v]
   #?(:clj (walk/stringify-keys v)
      :cljs (clj->js v)))
+
+(defn set-default! []
+  (utils/set-date-config! hydrate serialize))

--- a/src/matchbox/serialization/plain.cljc
+++ b/src/matchbox/serialization/plain.cljc
@@ -1,0 +1,21 @@
+(ns matchbox.serialization.plain
+  (:require
+    [clojure.walk :as walk])
+  (:import
+    (java.util HashMap ArrayList)))
+
+(defn hydrate-raw [x]
+  #?(:cljs x
+     :clj
+     (cond
+       (instance? HashMap x) (recur (into {} x))
+       (instance? ArrayList x) (recur (into [] x))
+       :else x)))
+
+(defn hydrate [v]
+  #?(:clj  (walk/prewalk hydrate-raw v)
+     :cljs (js->clj v)))
+
+(defn serialize [v]
+  #?(:clj (walk/stringify-keys v)
+     :cljs (clj->js v)))

--- a/src/matchbox/serialization/sorted.cljc
+++ b/src/matchbox/serialization/sorted.cljc
@@ -1,0 +1,24 @@
+(ns matchbox.serialization.sorted
+  (:require
+    [clojure.walk :as walk]
+    [matchbox.serialization.keyword :as keyword])
+  (:import
+    (java.util HashMap ArrayList)
+    (clojure.lang PersistentTreeMap)))
+
+(defn map->sorted [m]
+  (if (instance? PersistentTreeMap m) m (into (sorted-map) (map (juxt (comp keyword key) val) m))))
+
+(defn hydrate-shallow [x]
+  (cond
+    #?@(:clj [(instance? HashMap x) (recur (map->sorted x))
+              (instance? ArrayList x) (recur (into [] x))])
+    (map? x) (map->sorted x)
+    :else (keyword/hydrate-kw x)))
+
+(defn hydrate [v]
+  #?(:clj  (walk/prewalk hydrate-shallow v)
+     :cljs (walk/postwalk hydrate-shallow (js->clj v))))
+
+(def serialize keyword/serialize)
+

--- a/src/matchbox/serialization/sorted.cljc
+++ b/src/matchbox/serialization/sorted.cljc
@@ -3,23 +3,21 @@
     [clojure.walk :as walk]
     [matchbox.serialization.keyword :as keyword]
     [matchbox.utils :as utils])
-  (:import
-    (java.util HashMap ArrayList)
-    (clojure.lang PersistentTreeMap)))
+  #?(:clj (:import (java.util HashMap ArrayList))))
 
 (defn map->sorted [m]
-  (if (instance? PersistentTreeMap m) m (into (sorted-map) (map (juxt (comp keyword key) val) m))))
+  (if (sorted? m) m (into (sorted-map) (map (juxt (comp keyword key) val) m))))
 
 (defn hydrate-shallow [x]
   (cond
     #?@(:clj [(instance? HashMap x) (recur (map->sorted x))
               (instance? ArrayList x) (recur (into [] x))])
     (map? x) (map->sorted x)
+    #?@(:cljs [(array? x) (vec x)
+               (identical? js/Object (type x)) (into (sorted-map) (for [k (js-keys x)] [(keyword k) (aget x k)]))])
     :else (keyword/hydrate-kw x)))
 
-(defn hydrate [v]
-  #?(:clj  (walk/prewalk hydrate-shallow v)
-     :cljs (walk/postwalk hydrate-shallow (js->clj v))))
+(defn hydrate [v] (walk/prewalk hydrate-shallow v))
 
 (def serialize keyword/serialize)
 

--- a/src/matchbox/serialization/sorted.cljc
+++ b/src/matchbox/serialization/sorted.cljc
@@ -1,7 +1,8 @@
 (ns matchbox.serialization.sorted
   (:require
     [clojure.walk :as walk]
-    [matchbox.serialization.keyword :as keyword])
+    [matchbox.serialization.keyword :as keyword]
+    [matchbox.utils :as utils])
   (:import
     (java.util HashMap ArrayList)
     (clojure.lang PersistentTreeMap)))
@@ -22,3 +23,5 @@
 
 (def serialize keyword/serialize)
 
+(defn set-default! []
+  (utils/set-date-config! hydrate serialize))

--- a/src/matchbox/serialization/stable.cljc
+++ b/src/matchbox/serialization/stable.cljc
@@ -1,0 +1,25 @@
+(ns matchbox.serialization.stable
+  (:require
+    [clojure.walk :as walk]
+    [matchbox.serialization.keyword :as keyword]
+    [linked.core :as linked]
+    [linked.map])
+  (:import
+    (java.util HashMap ArrayList)
+    (clojure.lang PersistentTreeMap)))
+
+(defn map->linked [m]
+  (if (instance? linked.map.LinkedMap m) m (linked.map/->linked-map (map (juxt (comp keyword key) val) m))))
+
+(defn hydrate-shallow [x]
+  (cond
+    #?@(:clj [(instance? HashMap x) (recur (map->linked x))
+              (instance? ArrayList x) (recur (into [] x))])
+    (map? x) (map->linked x)
+    :else (keyword/hydrate-kw x)))
+
+(defn hydrate [v]
+  #?(:clj  (walk/prewalk hydrate-shallow v)
+     :cljs (walk/postwalk hydrate-shallow (js->clj v))))
+
+(def serialize keyword/serialize)

--- a/src/matchbox/serialization/stable.cljc
+++ b/src/matchbox/serialization/stable.cljc
@@ -2,8 +2,8 @@
   (:require
     [clojure.walk :as walk]
     [matchbox.serialization.keyword :as keyword]
-    [linked.core :as linked]
-    [linked.map])
+    [linked.map]
+    [matchbox.utils :as utils])
   (:import
     (java.util HashMap ArrayList)
     (clojure.lang PersistentTreeMap)))
@@ -23,3 +23,6 @@
      :cljs (walk/postwalk hydrate-shallow (js->clj v))))
 
 (def serialize keyword/serialize)
+
+(defn set-default! []
+  (utils/set-date-config! hydrate serialize))

--- a/src/matchbox/utils.cljc
+++ b/src/matchbox/utils.cljc
@@ -23,12 +23,26 @@
 
 ;;
 
+(defprotocol ISerializer
+  (get-hydrate [this])
+  (set-hydrate! [this val])
+  (get-serialize [this])
+  (set-serialize! [this val]))
+
+(deftype Serializer [#?(:clj ^:volatile-mutable hydrate :cljs ^:mutable hydrate)
+                     #?(:clj ^:volatile-mutable serialize :cljs ^:mutable serialize)]
+  ISerializer
+  (get-hydrate [_] hydrate)
+  (set-hydrate! [_ val] (set! hydrate val))
+  (get-serialize [_] serialize)
+  (set-serialize! [_ val] (set! serialize val)))
+
 (defn set-date-config! [hydrate serialize]
-  (swap! #?(:clj @(resolve 'matchbox.core/data-config)
-            :cljs matchbox.core/data-config)
-         assoc
-         :hydrate hydrate
-         :serialize serialize))
+  (-> ^Serializer
+      #?(:clj @(resolve 'matchbox.core/data-config)
+         :cljs matchbox.core/data-config)
+      (set-hydrate! hydrate)
+      (set-serialize! serialize)))
 
 #?(:clj (def repl-out *out*))
 

--- a/src/matchbox/utils.cljc
+++ b/src/matchbox/utils.cljc
@@ -24,17 +24,17 @@
 ;;
 
 (defprotocol ISerializer
-  (get-hydrate [this])
+  (hydrate [this x])
   (set-hydrate! [this val])
-  (get-serialize [this])
+  (serialize [this x])
   (set-serialize! [this val]))
 
 (deftype Serializer [#?(:clj ^:volatile-mutable hydrate :cljs ^:mutable hydrate)
                      #?(:clj ^:volatile-mutable serialize :cljs ^:mutable serialize)]
   ISerializer
-  (get-hydrate [_] hydrate)
+  (hydrate [_ x] (hydrate x))
   (set-hydrate! [_ val] (set! hydrate val))
-  (get-serialize [_] serialize)
+  (serialize [_ x] (serialize x))
   (set-serialize! [_ val] (set! serialize val)))
 
 (defn set-date-config! [hydrate serialize]

--- a/src/matchbox/utils.cljc
+++ b/src/matchbox/utils.cljc
@@ -13,7 +13,7 @@
     (str/join "/" (map name korks))
     (when korks (name korks))))
 
-(defn no-op [& _])
+(defn no-op ([_]) ([_ _]) ([_ _ _]) ([_ _ _ & _]))
 
 (defn extract-cb [args]
   (if (and (>= (count args) 2)
@@ -23,9 +23,16 @@
 
 ;;
 
+(defn set-date-config! [hydrate serialize]
+  (swap! #?(:clj @(resolve 'matchbox.core/data-config)
+            :cljs matchbox.core/data-config)
+         assoc
+         :hydrate hydrate
+         :serialize serialize))
+
 #?(:clj (def repl-out *out*))
 
-#?(:cj
+#?(:clj
     (defn prn
       "Like clojure.core/prn, but always bound to root thread's *out*"
       [& args]

--- a/src/matchbox/utils.cljc
+++ b/src/matchbox/utils.cljc
@@ -25,24 +25,22 @@
 
 (defprotocol ISerializer
   (hydrate [this x])
-  (set-hydrate! [this val])
   (serialize [this x])
-  (set-serialize! [this val]))
+  (config! [this hydrate serialize]))
 
-(deftype Serializer [#?(:clj ^:volatile-mutable hydrate :cljs ^:mutable hydrate)
-                     #?(:clj ^:volatile-mutable serialize :cljs ^:mutable serialize)]
+(deftype Serializer
+  [#?(:clj ^:volatile-mutable hydrate :cljs ^:mutable hydrate)
+   #?(:clj ^:volatile-mutable serialize :cljs ^:mutable serialize)]
   ISerializer
   (hydrate [_ x] (hydrate x))
-  (set-hydrate! [_ val] (set! hydrate val))
   (serialize [_ x] (serialize x))
-  (set-serialize! [_ val] (set! serialize val)))
+  (config! [_ h s] (set! hydrate h) (set! serialize s)))
 
 (defn set-date-config! [hydrate serialize]
   (-> ^Serializer
       #?(:clj @(resolve 'matchbox.core/data-config)
          :cljs matchbox.core/data-config)
-      (set-hydrate! hydrate)
-      (set-serialize! serialize)))
+      (config! hydrate serialize)))
 
 #?(:clj (def repl-out *out*))
 

--- a/test/matchbox/core_test.cljs
+++ b/test/matchbox/core_test.cljs
@@ -68,7 +68,7 @@
       ;; (sorts by name on equality)
       (m/set-priority! child-1 "a")
       (m/set-priority-in! ref (m/key child-2) 0)
-      (m/deref ref (fn [v] (is (= [3 2 1] (vals v))) (done))))))
+      (m/deref-list ref (fn [v] (is (= [3 2 1] v)) (done))))))
 
 (deftest reset-with-priority!-test
   (async done
@@ -76,7 +76,7 @@
       (m/reset-with-priority-in! ref "a" 1 "a")
       (m/reset-with-priority-in! ref "b" 2 0)
       (m/reset-in! ref "c" 3)
-      (m/deref ref (fn [v] (is (= [3 2 1] (vals v))) (done))))))
+      (m/deref-list ref (fn [v] (is (= [3 2 1] v)) (done))))))
 
 (deftest disconnect!-reconnect!-test
   ;; default is connected

--- a/test/matchbox/serialization_test.cljc
+++ b/test/matchbox/serialization_test.cljc
@@ -4,54 +4,51 @@
        [cljs.test :refer [deftest is testing async]]
        [cljs.core.async.macros :refer [go]]))
   (:require
-    #?(:clj [clojure.test :refer [deftest is testing]]
-        :cljs [cljs.test])
     [matchbox.core :as m]
     [matchbox.testing :refer [db-uri random-ref]]
-    [matchbox.testing
-     #?@(:clj [:refer [is=
-                       round-trip=
-                       round-trip<]]
-         :cljs [:refer-macros [is=
-                               round-trip=
-                               round-trip<]
-                :include-macros true])]
-    [#?(:clj clojure.core.async
-        :cljs cljs.core.async)
-     :refer [chan <! >! #?(:clj go)]]))
+    [matchbox.testing #?@(:clj  [:refer [is= round-trip= round-trip<]]
+                          :cljs [:refer-macros [is= round-trip= round-trip<] :include-macros true])]
+    #?(:clj [clojure.test :refer [deftest is testing]] :cljs [cljs.test])
+    [#?(:clj clojure.core.async :cljs cljs.core.async) :refer [chan <! >! #?(:clj go)]]
+    [matchbox.serialization.plain :as plain]
+    [matchbox.serialization.keyword :as keyword]
+    [matchbox.serialization.sorted :as sorted]
+    [matchbox.serialization.stable :as stable])
+  (:import
+    (java.util HashMap)))
 
 ;; serialize / deserialize (specs)
 
 #?(:clj
-(deftest serialize-test
-  ;; map keys from keywords -> strings
-  (let [orig {:hello "world" :bye "world"}
-        tran (m/serialize orig)]
-    (is (contains? tran "hello"))
-    (is (not (contains? tran :hello))))
-  ;; values are unchanged
-  (testing "bool, long, float, vector, string, set, list"
-    (doseq [x [true [1 2 3 4] 150.0 "hello" #{1 2 3} '(3 2 1)]]
-      (is (= x (m/serialize x)))))
-  (testing "keyword"
-    (is (= ":a" (m/serialize :a))))))
+   (deftest serialize-test
+     ;; map keys from keywords -> strings
+     (let [orig {:hello "world" :bye "world"}
+           tran (m/serialize orig)]
+       (is (contains? tran "hello"))
+       (is (not (contains? tran :hello))))
+     ;; values are unchanged
+     (testing "bool, long, float, vector, string, set, list"
+       (doseq [x [true [1 2 3 4] 150.0 "hello" #{1 2 3} '(3 2 1)]]
+         (is (= x (m/serialize x)))))
+     (testing "keyword"
+       (is (= ":a" (m/serialize :a))))))
 
 #?(:clj
-(deftest hydrate-test
-  ;; map keys from strings -> keywords
-  (let [orig {"hello" "world" "bye" "world"}
-        tran (m/hydrate orig)]
-    (is (contains? tran :hello))
-    (is (not (contains? (set (keys tran)) "hello"))))
-  ;; values are unchanged
-  (testing "bool, long, float, vector, string, keyword, set, list"
-    (doseq [x [true [1 2 3 4] 150.0 "hello" :a #{1 2 3} '(3 2 1)]]
-      (is (= x (m/hydrate x)))))))
+   (deftest hydrate-test
+     ;; map keys from strings -> keywords
+     (let [orig {"hello" "world" "bye" "world"}
+           tran (m/hydrate orig)]
+       (is (contains? tran :hello))
+       (is (not (contains? (set (keys tran)) "hello"))))
+     ;; values are unchanged
+     (testing "bool, long, float, vector, string, keyword, set, list"
+       (doseq [x [true [1 2 3 4] 150.0 "hello" :a #{1 2 3} '(3 2 1)]]
+         (is (= x (m/hydrate x)))))))
 
 (deftest serialize-hydrate-test
   (is (= {:a 1, :b #?(:cljs [:b :a] :clj #{:a :b})}
          (m/hydrate
-          (m/serialize {"a" 1, "b" #{:a :b}})))))
+           (m/serialize {"a" 1, "b" #{:a :b}})))))
 
 
 ;; round trip (integration)
@@ -68,12 +65,12 @@
     ;; Cast down from extended types though
     (round-trip= 3.0 3N)
     (round-trip< 4M value
-                 #?(:clj (is (instance? Double value))
-                    :cljs (is (= js/Number (type value)))))
+      #?(:clj  (is (instance? Double value))
+         :cljs (is (= js/Number (type value)))))
     ;; Unless the decimal portion is explicit..
     (round-trip< 4.0M value
-                 #?(:clj (is (instance? Double value))
-                    :cljs (is (= js/Number (type value)))))
+      #?(:clj  (is (instance? Double value))
+         :cljs (is (= js/Number (type value)))))
     #?(:clj
        (round-trip= 4.3E90 4.3E90M)))
 
@@ -86,9 +83,9 @@
 
   (testing "map"
     (round-trip= {:a 1, :b 2}
-                     {"a" 1, :b 2})
+                 {"a" 1, :b 2})
     (round-trip= {:nested {:data 4}}
-                     {"nested" {"data" 4}}))
+                 {"nested" {"data" 4}}))
 
   (testing "list"
     (round-trip= [1 2 3 4] '(1 2 3 4)))
@@ -98,9 +95,34 @@
 
   (testing "set"
     (round-trip< #{1 2 3 4} result
-                 (is (vector? result))
-                 (is (= [1 2 3 4] (sort result)))))
+      (is (vector? result))
+      (is (= [1 2 3 4] (sort result)))))
 
   (testing "richer data"
     (round-trip= {:a-field [2]} (ARecord. [2]))
     (round-trip= {:an_attr [3]} (AType. #{3}))))
+
+
+(def ref-map
+  (reduce
+    (fn [#?(:clj ^HashMap acc :cljs (js/Object.)) [k v]]
+      #?(:clj (.put acc k v) :cjls (aset acc k v))
+      acc)
+    (let [base {"a" {"b" {"c" [{"d" "e" "f" ":f"}]}}}]
+      #?(:clj (HashMap. base) :cjls (clj->js base)))
+    (map vector (map (comp str char) (range 98 123)) (range 25))))
+
+(deftest custom-serializers-test
+  (testing "Keys as expected"
+    (is (every? string? (keys (plain/hydrate ref-map))))
+    (is (every? keyword? (keys (keyword/hydrate ref-map))))
+    (is (every? keyword? (keys (sorted/hydrate ref-map))))
+    (is (every? keyword? (keys (stable/hydrate ref-map)))))
+  (testing "Values as expected"
+    (is (= ":f" (get-in (plain/hydrate ref-map) ["a" "b" "c" 0 "f"])))
+    (is (= :f (get-in (keyword/hydrate ref-map) [:a :b :c 0 :f])))
+    (is (= :f (get-in (sorted/hydrate ref-map) [:a :b :c 0 :f])))
+    (is (= :f (get-in (stable/hydrate ref-map) [:a :b :c 0 :f]))))
+  (testing "Sorted as expected"
+    (is (= (sort (keys (sorted/hydrate ref-map))) (keys (sorted/hydrate ref-map))))
+    (is (= (sort (keys (stable/hydrate ref-map))) (keys (stable/hydrate ref-map))))))

--- a/test/matchbox/serialization_test.cljc
+++ b/test/matchbox/serialization_test.cljc
@@ -14,8 +14,7 @@
     [matchbox.serialization.keyword :as keyword]
     [matchbox.serialization.sorted :as sorted]
     [matchbox.serialization.stable :as stable])
-  (:import
-    (java.util HashMap)))
+#?(:clj (:import (java.util HashMap))))
 
 ;; serialize / deserialize (specs)
 
@@ -105,11 +104,11 @@
 
 (def ref-map
   (reduce
-    (fn [#?(:clj ^HashMap acc :cljs (js/Object.)) [k v]]
-      #?(:clj (.put acc k v) :cjls (aset acc k v))
+    (fn [#?(:clj ^HashMap acc :cljs acc) [k v]]
+      #?(:clj (.put acc k v) :cljs (aset acc k v))
       acc)
     (let [base {"a" {"b" {"c" [{"d" "e" "f" ":f"}]}}}]
-      #?(:clj (HashMap. base) :cjls (clj->js base)))
+      #?(:clj (HashMap. base) :cljs (clj->js base)))
     (map vector (map (comp str char) (range 98 123)) (range 25))))
 
 (deftest custom-serializers-test

--- a/test/matchbox/serialization_test.cljc
+++ b/test/matchbox/serialization_test.cljc
@@ -42,7 +42,7 @@
   (let [orig {"hello" "world" "bye" "world"}
         tran (m/hydrate orig)]
     (is (contains? tran :hello))
-    (is (not (contains? tran "hello"))))
+    (is (not (contains? (set (keys tran)) "hello"))))
   ;; values are unchanged
   (testing "bool, long, float, vector, string, keyword, set, list"
     (doseq [x [true [1 2 3 4] 150.0 "hello" :a #{1 2 3} '(3 2 1)]]


### PR DESCRIPTION
Closes #73 

Sorry for the delay @dotboris, we just missed each other last time I passed through.

Just before implementing this, I realised that using the optional `xform` parameter (eg. `(mr/sync-r ref (partial into (sorted-map)))`) should also be sufficient. But that does involve a awkward extra allocation path over the data, and doesn't handle nested maps. Handling those would make it even more awkward 😆 

Here I've just made `sorted-maps` the default. But the implementation leaks out, and the `clojure.lang.Sorted` property comes at a price: keys are now typed.

```clojure
((into (sorted-map) {:a 1 :b 2}) :a)
 => 1

((into (sorted-map) {:a 1 :b 2}) "a")
 ;; Java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.Keyword

(into (sorted-map) {:a 1 'c 2}) => 
 ;; Java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.Symbol
```

This could break quite a bit of old code, so I'm not completely comfortable with this. Perhaps using something like [Linked](https://github.com/frankiesardo/linked)'s order-preserving maps would be preferable, with the added bonus of then working with queries and/or custom priorities.

But I'm loath to add another dependency, and also this "preserve insert order" property is perhaps more confusing than helpful when you start manipulating the data. Or perhaps not a real issue - since the default keys are server generated and monotonically increasing..

The cop out would be to just implement #51 and let poor users choose their trade-off. 

That burns down the issue queue fastest, so I'm copping out 😄 